### PR TITLE
chore: add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,13 @@
       "pre-push": "branch-name-lint"
     }
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/XD2Sketch/react-oauth-popup.git"
+  },
+  "bugs": {
+    "url": "https://github.com/XD2Sketch/react-oauth-popup/issues"
+  },
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
This is required to make it possible to goto GH repo from NPM registry