### PR TITLE
optional props

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,8 @@ type IWindowProps = {
   height: number;
 };
 
-type IPopupProps = IWindowProps & {
+type IPopupProps = Partial<Omit<IWindowProps, 'url'>> & {
+  url: string;
   onClose: () => void;
   onCode: (code: string, params: URLSearchParams) => void;
   children: React.ReactNode;


### PR DESCRIPTION
In TypeScript, the component requires the width, height, and title parameters. My changes fix this issue.